### PR TITLE
Fixed filter css on mobile

### DIFF
--- a/styles/filter.css
+++ b/styles/filter.css
@@ -1,13 +1,18 @@
 #filter {
 	display: flex;
 	flex-direction: row;
-	justify-content: center;
+	justify-content: space-around;
 	margin-top: 0.2rem;
+	height: auto;
 	width: 100%;
 }
 
 #filter .grade {
-	max-width: 12.5%;
+	margin: 0;
+	max-width: 2.5rem;
+	max-height: 2.5rem;
+	height: 12.5vw;
+	width: 12.5vw;
 }
 
 #filter .grade.inactive {


### PR DESCRIPTION
# Summary
- fixed issue where filter bar would extend off the screen
    - landscape and portrait orientation

# Screenshots
![img_0489](https://user-images.githubusercontent.com/5777094/30008950-4bdf24c6-90f2-11e7-9771-4e7578de91db.PNG)
![img_0490](https://user-images.githubusercontent.com/5777094/30008951-4cdae554-90f2-11e7-8941-07722ecd3d75.PNG)
