### PR TITLE
Finalized facebook login

### DIFF
--- a/scripts/loader.js
+++ b/scripts/loader.js
@@ -61,15 +61,6 @@ $(document).ready(() => {
 	// Load routes from firebase
 	LOADER.loadRoutes().then((routes) => {
 		LOADER.routes = routes;
-		//LOGIN.verify();
-
-		let options = {};
-		options.reset = true;
-		NAV.transition('#menu', options);
-
-
-		// let route = routes[0];
-		// NAV.populateRoute(route);
-		// NAV.transition('#route');
+		LOGIN.verify();
 	});
 });

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -1,19 +1,47 @@
 let LOGIN = {
-	name: 'Roman Rogowski',
+	name: null,
+	userID: null,
+
+	// Handle race condition (database vs. Facebook API)
+	fbReady: false,
 
 	// Check facebook authentication status
 	verify: () => {
+		// Handle race condition where data from
+		// database has loaded before the Facebook
+		// API is ready.
+		if (! LOGIN.fbReady) {
+			$(window).on('LOGIN.fbReady', LOGIN.verify);
+			return;
+		}
+
 		FB.getLoginStatus((response) => {
 			let options = {};
 			options.reset = true;
 
 			if (response.status == 'connected') {
-				NAV.transition('#menu', options);
+				let userID = response.authResponse.userID;
+				let name = LOGIN.getName(userID);
+				name.then(($name) => {
+					LOGIN.name = $name;
+					LOGIN.userID = userID;
+					NAV.transition('#menu', options);
+				});
+
 			} else {
 				NAV.transition('#login', options);
 			}
 		});
-	}
+	},
+
+	// Get Facebook name from logged in user id
+	getName: (userID) => {
+		return new Promise((resolve, reject) => {
+			FB.api(userID, (response) => {
+				resolve(response.name);
+			});
+		});
+	},
 };
 
 // Called when the FB SDK is loaded
@@ -24,4 +52,16 @@ window.fbAsyncInit = () => {
 		xfbml      : true,
 		version    : 'v2.10'
 	});
+
+	LOGIN.fbReady = true;
+	$(window).trigger('LOGIN.fbReady');
 };
+
+// Load the facebook SDK
+(function(d, s, id) {
+	var js, fjs = d.getElementsByTagName(s)[0];
+	if (d.getElementById(id)) {return;}
+	js = d.createElement(s); js.id = id;
+	js.src = "http://connect.facebook.net/en_US/sdk.js";
+	fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));


### PR DESCRIPTION
# Summary
- users can now log in with ("Continue With") Facebook
    - login persists when users reload the app
    - `LOGIN` variable now has entries to get the user's `name` and `userID`